### PR TITLE
Fix bug when doing get_data from an Array with one element.

### DIFF
--- a/khiva/array.py
+++ b/khiva/array.py
@@ -213,7 +213,11 @@ class Array:
         KhivaLibrary().c_khiva_library.get_data(ctypes.pointer(self.arr_reference), ctypes.pointer(c_result_array))
 
         dims = self.get_dims()
-        dims = dims[dims > 1]
+        if dims[dims > 1].size > 0:
+            dims = dims[dims > 1]
+        else:
+            dims = np.array([1])
+
         a = np.array(c_result_array)
 
         if self._is_complex():

--- a/tests/unit_tests/array_unit_tests.py
+++ b/tests/unit_tests/array_unit_tests.py
@@ -404,7 +404,6 @@ class ArrayTest(unittest.TestCase):
         self.assertEqual(a.to_list()[0], 1)
 
 
-
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(ArrayTest)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/unit_tests/array_unit_tests.py
+++ b/tests/unit_tests/array_unit_tests.py
@@ -394,6 +394,15 @@ class ArrayTest(unittest.TestCase):
         a = Array([1, 2, 3, 4])
         self.assertTrue(a)
 
+    def testGetData1(self):
+        a = Array([1])
+        np.testing.assert_array_equal(a.to_numpy(), np.array([1]))
+
+    def testToList1(self):
+        a = Array([1])
+        self.assertIs(type(a.to_list()), list)
+
+
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(ArrayTest)

--- a/tests/unit_tests/array_unit_tests.py
+++ b/tests/unit_tests/array_unit_tests.py
@@ -396,11 +396,12 @@ class ArrayTest(unittest.TestCase):
 
     def testGetData1(self):
         a = Array([1])
-        np.testing.assert_array_equal(a.to_numpy(), np.array([1]))
+        np.testing.assert_array_equal(a._get_data(), np.array([1]))
 
     def testToList1(self):
         a = Array([1])
         self.assertIs(type(a.to_list()), list)
+        self.assertEqual(a.to_list()[0], 1)
 
 
 


### PR DESCRIPTION
This PR solves one issue when doing get_data().tolist() on a Khiva.Array with one element.

### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits have been squashed if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


## License
- [ ] Add a [Mozilla Public License 2.0 license header](http://mozilla.org/MPL/2.0/) to all the new files.


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
