### PR TITLE
Fix issue with numpy interop

### DIFF
--- a/tests/unit_tests/array_unit_tests.py
+++ b/tests/unit_tests/array_unit_tests.py
@@ -30,19 +30,41 @@ class ArrayTest(unittest.TestCase):
     def setUp(self):
         set_backend(KHIVABackend.KHIVA_BACKEND_CPU)
 
+    def test_real_1d_creation(self):
+        a = Array([1, 5, 3, 1])
+        np.testing.assert_array_equal(a.dims, np.array([4, 1, 1, 1]))
+
+    def test_single_value_creation(self):
+        a = Array([1])
+        np.testing.assert_array_equal(a.dims, np.array([1, 1, 1, 1]))
+
     def test_real_1d(self):
         a = Array([1, 2, 3, 4, 5, 6, 7, 8])
         expected = np.array([1, 2, 3, 4, 5, 6, 7, 8])
         np.testing.assert_array_equal(a.to_numpy(), expected)
+
+    def test_real_2d_creation(self):
+        a = Array([[1, 5, 3, 1], [2, 6, 9, 8], [3, 4, 1, 3]])
+        np.testing.assert_array_equal(a.dims, np.array([4, 3, 1, 1]))
 
     def test_real_2d(self):
         a = Array([[1, 2, 3, 4], [5, 6, 7, 8]])
         expected = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
         np.testing.assert_array_equal(a.to_numpy(), expected)
 
+    def test_real_3d_creation(self):
+        a = Array([[[1, 5, 3, 1], [2, 6, 9, 8], [3, 4, 1, 3]],
+                   [[3, 7, 4, 2], [4, 8, 1, 9], [1, 5, 9, 2]]])
+        np.testing.assert_array_equal(a.dims, np.array([4, 3, 2, 1]))
+
     def test_real_3d(self):
         a = Array([[[1, 5], [2, 6]], [[3, 7], [4, 8]]])
         expected = np.array([[[1, 5], [2, 6]], [[3, 7], [4, 8]]])
+        np.testing.assert_array_equal(a.to_numpy(), expected)
+
+    def test_real_3d_large_column(self):
+        a = Array([[[1, 5, 3], [2, 6, 9]], [[3, 7, 4], [4, 8, 1]]])
+        expected = np.array([[[1, 5, 3], [2, 6, 9]], [[3, 7, 4], [4, 8, 1]]])
         np.testing.assert_array_equal(a.to_numpy(), expected)
 
     def test_real_4d(self):
@@ -254,7 +276,7 @@ class ArrayTest(unittest.TestCase):
     def testRow(self):
         a = Array(np.transpose([[1, 2], [3, 4]]), dtype.s32)
         c = a.get_row(0)
-        np.testing.assert_array_equal(c.to_numpy(), [1, 2])
+        np.testing.assert_array_equal(c.to_numpy(), np.transpose(np.array([[1, 2]])))
 
     def testRows(self):
         a = Array(np.transpose([[1, 2], [3, 4], [5, 6]]), dtype.s32)

--- a/tests/unit_tests/matrix_unit_tests.py
+++ b/tests/unit_tests/matrix_unit_tests.py
@@ -68,8 +68,8 @@ class MatrixTest(unittest.TestCase):
         find_best_n_motifs_result = find_best_n_motifs(stomp_result[0], stomp_result[1], 3, 1)
         a = find_best_n_motifs_result[1].to_numpy()
         b = find_best_n_motifs_result[2].to_numpy()
-        np.testing.assert_array_almost_equal(a, np.array([[12, 12], [12, 12]]), decimal=self.DECIMAL)
-        np.testing.assert_array_almost_equal(b, np.array([[1, 1], [1, 1]]), decimal=self.DECIMAL)
+        np.testing.assert_array_almost_equal(a, np.array([[[12], [12]], [[12], [12]]]), decimal=self.DECIMAL)
+        np.testing.assert_array_almost_equal(b, np.array([[[1], [1]], [[1], [1]]]), decimal=self.DECIMAL)
 
     def test_find_best_n_motifs_mirror(self):
         stomp_result = stomp_self_join(Array([10.1, 11, 10.2, 10.15, 10.775, 10.1, 11, 10.2], dtype.f32), 3)


### PR DESCRIPTION
Reading from an Array:
  - When an Array of real or complex numbers with more than two dimensions was
  benig converted to numpy this conversion didn't return an np.array
  with a proper shape.

Creating an Array:
  - When an Array of real numbers with more than two dimensions was
  built. The shape in the device (arrayfire) was not correct.
  - For complex numbers it occurrs with more than one dimension.

Make sure you have checked _all_ steps below.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits have been squashed if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


## License
- [ ] Add a [Mozilla Public License 2.0 license header](http://mozilla.org/MPL/2.0/) to all the new files.


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
