### PR TITLE
Fix python 3.9 and 3.8 error

### DIFF
--- a/khiva/library.py
+++ b/khiva/library.py
@@ -31,7 +31,8 @@ class KhivaLibrary(object):
                 if platform.system() == 'Darwin':
                     self.c_khiva_library = ctypes.CDLL('libkhiva_c.dylib')
                 elif platform.system() == 'Windows':
-                    if sys.version_info.major == 3 and sys.version_info.minor == 8:
+                    # This lines below are needed to find dll_dir in python 3.8 an above
+                    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
                         import os
                         os.add_dll_directory(os.getenv("KHIVA_DLL_DIR", default=r'C:\Program Files\Khiva\v0\lib'))
                     self.c_khiva_library = ctypes.CDLL('khiva_c.dll')


### PR DESCRIPTION
This MR fixes khiva-python dll location for python 3.9 version